### PR TITLE
fix long-form name for cdk8s

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1064,7 +1064,7 @@ projects:
     files_skip_pattern: '(^|/)_?(vendor|Godeps|_workspace)/'
   cdk8s:
     order: 74
-    name: Cloud Deployment Kit for Kubernetes
+    name: Cloud Development Kit for Kubernetes
     status: Sandbox
     command_line:
       - 'cdk8s-team'


### PR DESCRIPTION
I noticed this little nit, cdk8s is a development kit, does not have any deployment functionality.

I'm not sure if this requires more changes. Please let me know if so, happy to do more.
