### PR TITLE
Fix contribution thresholds for OpenTelemetry voter eligibility

### DIFF
--- a/metrics/shared/project_developer_stats.sql
+++ b/metrics/shared/project_developer_stats.sql
@@ -266,7 +266,7 @@ from (
 where
   (sub.metric = 'events' and sub.value > 100 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'active_repos' and sub.value > 3 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'contributions' and sub.value > 10 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'contributions' and sub.value > 5 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'commit_comments' and sub.value > 3 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'comments' and sub.value > 20 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'reviews' and sub.value > 15 * {{project_scale}} * sqrt({{range}}/1450.0))
@@ -549,7 +549,7 @@ from (
 where
   (sub.metric = 'events' and sub.value > 80 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'active_repos' and sub.value > 3 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'contributions' and sub.value > 5 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'contributions' and sub.value > 2 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'commit_comments' and sub.value > 2 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'comments' and sub.value > 10 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'reviews' and sub.value > 5 * {{project_scale}} * sqrt({{range}}/1450.0))
@@ -790,7 +790,7 @@ from (
 where
   (sub.metric = 'events' and sub.value > 100 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'active_repos' and sub.value > 3 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'contributions' and sub.value > 5 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'contributions' and sub.value > 2 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'commit_comments' and sub.value > 2 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'comments' and sub.value > 10 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'reviews' and sub.value > 5 * {{project_scale}} * sqrt({{range}}/1450.0))


### PR DESCRIPTION
- Reduce All_All contribution threshold from 10x to 5x multiplier
- Reduce RepoGroup_All contribution threshold from 5x to 2x multiplier
- Reduce All_Country contribution threshold from 5x to 2x multiplier
- This addresses the 25-contribution cutoff issue for OpenTelemetry elections
- Now includes developers with lower activity levels for voter roll generation

Fixes: OpenTelemetry election voter roll missing contributors with <25 contributions

Please make sure that you follow instructions from [CONTRIBUTING](https://github.com/cncf/devstats/blob/master/CONTRIBUTING.md)

Specially:
- Check if all tests pass, see [TESTING](https://github.com/cncf/devstats/blob/master/TESTING.md) for deatils.
- Make sure you've added test coverage for new features/metrics.
- Make sure you have updated documentation.
- If you added a new metric, please make sure you have been following instructions about [adding new metric](https://github.com/cncf/devstats/blob/master/METRICS.md).
