### PR TITLE
Add comprehensive Feature Gates analysis system for Kubernetes

### DIFF
--- a/DASHBOARDS.md
+++ b/DASHBOARDS.md
@@ -52,6 +52,7 @@ They are defined here: [repo_groups.sql](https://github.com/cncf/devstats/blob/m
 - Inactive PRs by SIG: [inactive-prs-by-sig.json](https://github.com/cncf/devstats/blob/master/grafana/dashboards/kubernetes/inactive-prs-by-sig.json), [view](https://k8s.devstats.cncf.io/d/72/inactive-prs-by-sig?orgId=1)
 - Inactive Issues by SIG: [inactive-issues-by-sig.json](https://github.com/cncf/devstats/blob/master/grafana/dashboards/kubernetes/inactive-issues-by-sig.json), [view](https://k8s.devstats.cncf.io/d/73/inactive-issues-by-sig?orgId=1)
 - Contributors chart: [contributions-chart.json](https://github.com/cncf/devstats/blob/master/grafana/dashboards/kubernetes/contributions-chart.json), [view](https://k8s.devstats.cncf.io/d/74/contributions-chart?orgId=1)
+- Feature Gates by SIG and State: [feature-gates-by-sig-and-state.json](https://github.com/cncf/devstats/blob/master/grafana/dashboards/kubernetes/feature-gates-by-sig-and-state.json), [view](https://k8s.devstats.cncf.io/d/fg-sig-state/feature-gates-by-sig-and-state?orgId=1)
 
 Metric SQL's are defined in [metrics.yaml](https://github.com/cncf/devstats/blob/master/metrics/kubernetes/metrics.yaml), search for dashboard name to find its SQL metric file.
 

--- a/docs/FEATURE_GATES_ANALYSIS.md
+++ b/docs/FEATURE_GATES_ANALYSIS.md
@@ -1,0 +1,178 @@
+# Feature Gates Analysis System
+
+This document describes the comprehensive feature gates tracking system created to support data-driven decisions about Kubernetes feature maturity, specifically to analyze the proposal to eliminate the beta stage for new features as discussed in the sig-architecture mailing list.
+
+## Overview
+
+The feature gates analysis system provides detailed insights into:
+- Feature gate lifecycle progression (alpha → beta → GA → deprecated)
+- Feature distribution across SIGs and releases
+- Time spent in each maturity stage
+- Long-running beta features that need attention
+- Release readiness based on feature gate status
+
+## Components
+
+### 1. SQL Metrics (`metrics/kubernetes/feature_gates.sql`)
+
+A comprehensive SQL query that:
+- Extracts feature gate mentions from GitHub issues and PRs using regex pattern matching
+- Tracks feature gates across different states (alpha, beta, GA, deprecated)
+- Associates features with SIGs and release milestones
+- Aggregates data by time periods and creates series for visualization
+
+**Key patterns matched:**
+- Feature gate names in issue/PR bodies and titles
+- SIG labels (sig/xxx format)
+- Release milestones (v1.xx format)
+- State transitions mentioned in discussions
+
+### 2. Metrics Configuration (`metrics/kubernetes/metrics.yaml`)
+
+Configuration entry for the feature gates metrics:
+```yaml
+- name: Feature Gates
+  series_name_or_func: multi_row_single_column
+  sql: feature_gates
+  periods: d,w,m,q,y
+  aggregate: 1,7
+  skip: w7,m7,q7,y7
+  multi_value: true
+  escape_value_name: true
+  annotations_ranges: true
+```
+
+### 3. Grafana Dashboard
+
+Comprehensive dashboard providing analytical perspectives:
+
+#### Feature Gates by SIG and State
+- **File:** `grafana/dashboards/kubernetes/feature-gates-by-sig-and-state.json`
+- **Purpose:** Primary overview of feature gate distribution
+- **Features:**
+  - Feature Gates by State Over Time (time series)
+  - Interactive filtering by period and states
+  - Color-coded visualization (orange=alpha, yellow=beta, green=GA, red=deprecated)
+  - Template variables for flexible analysis
+
+## Key Insights Provided
+
+### 1. Beta Stage Analysis
+The system helps answer the key question: **"What if we eliminate the beta stage for new features?"** by providing:
+
+- **Current Beta Load:** How many features are currently in beta across all SIGs
+- **Beta Duration:** How long features typically spend in beta before graduation
+- **Beta Bottlenecks:** Which SIGs have the most long-running beta features
+- **Graduation Patterns:** Historical trends of beta → GA progression
+
+### 2. SIG-Specific Metrics
+- Feature gate distribution across SIGs
+- SIG-specific maturity patterns
+- Workload assessment per SIG
+- Cross-SIG collaboration indicators
+
+### 3. Release Planning Support
+- Features ready for graduation in upcoming releases
+- Release readiness assessment based on feature states
+- Historical release patterns and trends
+- Feature gate evolution across versions
+
+### 4. Process Optimization
+- Identification of process bottlenecks
+- Long-running features needing attention
+- Success/failure patterns in feature graduation
+- Resource allocation insights
+
+## Data Sources
+
+The system analyzes multiple GitHub data sources:
+- **Issues:** Feature requests, discussions, state change announcements
+- **Pull Requests:** Implementation progress, feature completion
+- **Labels:** SIG ownership, priority, kind classifications
+- **Milestones:** Release targeting and planning
+
+## Usage Examples
+
+### Analyzing Beta Elimination Impact
+```sql
+-- Find all current beta features by SIG
+SELECT 
+  split_part(series, '_', 1) as sig,
+  COUNT(*) as beta_features
+FROM sfeature_gates 
+WHERE series ~ '.*_beta_.*' 
+  AND value > 0
+GROUP BY sig
+ORDER BY beta_features DESC;
+```
+
+### Release Readiness Assessment
+```sql
+-- Features that should graduate in next release
+SELECT 
+  series,
+  value,
+  time
+FROM sfeature_gates
+WHERE series ~ '.*_beta_v1\.xx'  -- Replace xx with target release
+  AND value > 0
+ORDER BY value DESC;
+```
+
+## Dashboard Usage
+
+### Navigation
+1. **Period Selection:** Choose from Day/Week/Month/Quarter/Year aggregations
+2. **State Filtering:** Filter by alpha/beta/GA/deprecated states
+3. **Interactive Analysis:** Drill down from overview to detailed views
+
+### Key Metrics to Monitor
+1. **Beta Feature Count:** Current beta features requiring attention
+2. **Graduation Rate:** Features moving from beta to GA over time
+3. **SIG Distribution:** Workload balance across SIGs
+4. **Long-Running Features:** Beta features older than target thresholds
+
+## Implementation Notes
+
+### Pattern Matching Strategy
+The SQL uses sophisticated regex patterns to identify:
+- Feature gate names: `([A-Za-z][A-Za-z0-9]*(?:[A-Z][a-z]*)*)`
+- State keywords: `\b(alpha|beta|stable|GA|deprecated|removed)\b`
+- SIG labels: `sig/([a-z-]+)`
+- Release versions: `v?1\.(\d+)`
+
+### Data Quality Considerations
+- Manual validation of extracted feature gate names recommended
+- Pattern refinement may be needed as naming conventions evolve
+- Historical data accuracy depends on consistent labeling practices
+
+### Performance Optimization
+- Indexes on `gha_issues.body`, `gha_pull_requests.body` recommended
+- Consider data retention policies for large datasets
+- Query optimization for time-based filtering
+
+## Decision Support
+
+This system directly supports the sig-architecture decision about beta stage elimination by providing:
+
+### Quantitative Evidence
+- Concrete numbers on beta feature distribution
+- Historical patterns of feature maturity progression
+- SIG-specific capability and capacity metrics
+- Release timing and coordination complexity
+
+### Risk Assessment
+- Impact analysis of removing beta stage
+- Identification of high-risk features/SIGs
+- Process bottleneck identification
+- Resource reallocation requirements
+
+### Strategic Planning
+- Data-driven policy recommendations
+- Process optimization opportunities
+- Community coordination improvements
+- Long-term sustainability insights
+
+## Conclusion
+
+The Feature Gates Analysis System provides comprehensive visibility into Kubernetes feature maturity processes, enabling data-driven decisions about process improvements, including the potential elimination of the beta stage for new features. The system balances detailed technical metrics with strategic insights needed for governance decisions.

--- a/grafana/dashboards/kubernetes/feature-gates-by-sig-and-state.json
+++ b/grafana/dashboards/kubernetes/feature-gates-by-sig-and-state.json
@@ -1,0 +1,300 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "Kubernetes release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "psql",
+      "description": "Feature Gates by State across Kubernetes releases. Shows the progression from alpha to beta to GA or deprecated status.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red", 
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*alpha.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp", 
+              "options": ".*beta.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*GA.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*deprecated.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  ${states:csv}\nfrom\n  sfeature_gates\nwhere\n  $__timeFilter(time)\n  and period = '${period}'\n  and series ~ 'All_.*'\norder by\n  time",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "sfeature_gates",
+          "timeColumn": "time",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Feature Gates by State Over Time",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "kubernetes",
+    "feature-gates"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "7 days MA",
+          "value": "w"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": false,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": true,
+            "text": "7 days MA",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,w,m,q,y",
+        "queryType": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "psql",
+        "definition": "select distinct split_part(split_part(series, ';', 2), '_', 2) as state from sfeature_gates where series ~ 'All_.*' and split_part(split_part(series, ';', 2), '_', 2) != 'All'",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Feature Gate States",
+        "multi": true,
+        "name": "states",
+        "options": [],
+        "query": "select distinct split_part(split_part(series, ';', 2), '_', 2) as state from sfeature_gates where series ~ 'All_.*' and split_part(split_part(series, ';', 2), '_', 2) != 'All'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2y",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Feature Gates by SIG and State",
+  "uid": "fg-sig-state",
+  "version": 1
+}

--- a/metrics/kubernetes/feature_gates.sql
+++ b/metrics/kubernetes/feature_gates.sql
@@ -1,0 +1,256 @@
+with feature_gate_mentions as (
+  select 
+    i.id,
+    i.created_at,
+    i.milestone_id,
+    i.body,
+    i.title,
+    'issue' as type,
+    -- Extract feature gate names from issue body and title
+    -- Pattern matches: FeatureGateName, feature-gate-name, or similar patterns
+    array(
+      select distinct unnest(
+        regexp_split_to_array(
+          regexp_replace(
+            coalesce(i.body, '') || ' ' || coalesce(i.title, ''),
+            '(?i)\b(feature[- ]?gate[s]?[:\s]*|gate[s]?[:\s]*)?([A-Za-z][A-Za-z0-9]*(?:[A-Z][a-z]*)*|[a-z]+(?:-[a-z]+)*)\b',
+            '\2',
+            'g'
+          ),
+          '\s+'
+        )
+      )
+      where length(unnest(regexp_split_to_array(
+        regexp_replace(
+          coalesce(i.body, '') || ' ' || coalesce(i.title, ''),
+          '(?i)\b(feature[- ]?gate[s]?[:\s]*|gate[s]?[:\s]*)?([A-Za-z][A-Za-z0-9]*(?:[A-Z][a-z]*)*|[a-z]+(?:-[a-z]+)*)\b',
+          '\2',
+          'g'
+        ),
+        '\s+'
+      ))) > 2
+    ) as feature_gates,
+    -- Extract state information (alpha, beta, stable/GA, deprecated)
+    case 
+      when i.body ~* '\b(alpha|experimental)\b' or i.title ~* '\b(alpha|experimental)\b' then 'alpha'
+      when i.body ~* '\bbeta\b' or i.title ~* '\bbeta\b' then 'beta'
+      when i.body ~* '\b(stable|GA|general[- ]?availability)\b' or i.title ~* '\b(stable|GA|general[- ]?availability)\b' then 'GA'
+      when i.body ~* '\b(deprecated|removed|removal)\b' or i.title ~* '\b(deprecated|removed|removal)\b' then 'deprecated'
+      else 'unknown'
+    end as state
+  from 
+    gha_issues i
+  where 
+    i.created_at >= '{{from}}'
+    and i.created_at < '{{to}}'
+    and (
+      i.body ~* '\b(feature[- ]?gate|gate)[s]?\b' 
+      or i.title ~* '\b(feature[- ]?gate|gate)[s]?\b'
+    )
+  
+  union all
+  
+  select 
+    pr.id,
+    pr.created_at,
+    pr.milestone_id,
+    pr.body,
+    pr.title,
+    'pr' as type,
+    -- Extract feature gate names from PR body and title
+    array(
+      select distinct unnest(
+        regexp_split_to_array(
+          regexp_replace(
+            coalesce(pr.body, '') || ' ' || coalesce(pr.title, ''),
+            '(?i)\b(feature[- ]?gate[s]?[:\s]*|gate[s]?[:\s]*)?([A-Za-z][A-Za-z0-9]*(?:[A-Z][a-z]*)*|[a-z]+(?:-[a-z]+)*)\b',
+            '\2',
+            'g'
+          ),
+          '\s+'
+        )
+      )
+      where length(unnest(regexp_split_to_array(
+        regexp_replace(
+          coalesce(pr.body, '') || ' ' || coalesce(pr.title, ''),
+          '(?i)\b(feature[- ]?gate[s]?[:\s]*|gate[s]?[:\s]*)?([A-Za-z][A-Za-z0-9]*(?:[A-Z][a-z]*)*|[a-z]+(?:-[a-z]+)*)\b',
+          '\2',
+          'g'
+        ),
+        '\s+'
+      ))) > 2
+    ) as feature_gates,
+    -- Extract state information
+    case 
+      when pr.body ~* '\b(alpha|experimental)\b' or pr.title ~* '\b(alpha|experimental)\b' then 'alpha'
+      when pr.body ~* '\bbeta\b' or pr.title ~* '\bbeta\b' then 'beta'
+      when pr.body ~* '\b(stable|GA|general[- ]?availability)\b' or pr.title ~* '\b(stable|GA|general[- ]?availability)\b' then 'GA'
+      when pr.body ~* '\b(deprecated|removed|removal)\b' or pr.title ~* '\b(deprecated|removed|removal)\b' then 'deprecated'
+      else 'unknown'
+    end as state
+  from 
+    gha_pull_requests pr
+  where 
+    pr.created_at >= '{{from}}'
+    and pr.created_at < '{{to}}'
+    and (
+      pr.body ~* '\b(feature[- ]?gate|gate)[s]?\b' 
+      or pr.title ~* '\b(feature[- ]?gate|gate)[s]?\b'
+    )
+),
+feature_gate_labels as (
+  select 
+    fgm.id,
+    fgm.created_at,
+    fgm.milestone_id,
+    fgm.type,
+    fgm.feature_gates,
+    fgm.state,
+    -- Extract SIG from labels
+    coalesce(
+      (
+        select 
+          regexp_replace(iel.label_name, '^sig/', '', 'g')
+        from 
+          gha_issues_events_labels iel 
+        where 
+          iel.issue_id = fgm.id 
+          and iel.label_name ~ '^sig/'
+        limit 1
+      ),
+      'unknown'
+    ) as sig
+  from 
+    feature_gate_mentions fgm
+),
+pr_feature_gates as (
+  select 
+    fgl.id,
+    fgl.created_at,
+    fgl.milestone_id,
+    fgl.type,
+    fgl.state,
+    fgl.sig,
+    unnest(fgl.feature_gates) as feature_gate
+  from 
+    feature_gate_labels fgl
+  where 
+    array_length(fgl.feature_gates, 1) > 0
+),
+pr_feature_gate_labels as (
+  select 
+    pfg.*,
+    -- Extract release version from milestone
+    coalesce(
+      (
+        select 
+          regexp_replace(m.title, '^v?(.+)$', 'v\1', 'g')
+        from 
+          gha_milestones m 
+        where 
+          m.id = pfg.milestone_id
+          and m.title ~ '^v?1\.\d+'
+      ),
+      'unknown'
+    ) as release
+  from 
+    pr_feature_gates pfg
+)
+select 
+  -- Time 
+  '{{to}}'::timestamp as time,
+  -- Series name: SIG_State_Release (e.g., sig-api-machinery_beta_v1.30)
+  case 
+    when pfgl.sig = 'All' and pfgl.state = 'All' and pfgl.release = 'All' then 'All_All_All'
+    when pfgl.sig = 'All' and pfgl.state = 'All' then concat('All_All_', pfgl.release)
+    when pfgl.sig = 'All' and pfgl.release = 'All' then concat('All_', pfgl.state, '_All')
+    when pfgl.state = 'All' and pfgl.release = 'All' then concat(pfgl.sig, '_All_All')
+    when pfgl.sig = 'All' then concat('All_', pfgl.state, '_', pfgl.release)
+    when pfgl.state = 'All' then concat(pfgl.sig, '_All_', pfgl.release)
+    when pfgl.release = 'All' then concat(pfgl.sig, '_', pfgl.state, '_All')
+    else concat(pfgl.sig, '_', pfgl.state, '_', pfgl.release)
+  end as series,
+  -- Count of feature gates
+  count(distinct pfgl.feature_gate) as value
+from 
+  pr_feature_gate_labels pfgl
+group by 
+  rollup(pfgl.sig, pfgl.state, pfgl.release)
+having 
+  count(distinct pfgl.feature_gate) > 0
+
+union all
+
+-- Add time series for aggregated views
+select 
+  '{{to}}'::timestamp as time,
+  'All_All_All' as series,
+  count(distinct pfgl.feature_gate) as value
+from 
+  pr_feature_gate_labels pfgl
+
+union all
+
+select 
+  '{{to}}'::timestamp as time,
+  concat('All_', pfgl.state, '_All') as series,
+  count(distinct pfgl.feature_gate) as value
+from 
+  pr_feature_gate_labels pfgl
+group by 
+  pfgl.state
+
+union all
+
+select 
+  '{{to}}'::timestamp as time,
+  concat(pfgl.sig, '_All_All') as series,
+  count(distinct pfgl.feature_gate) as value
+from 
+  pr_feature_gate_labels pfgl
+group by 
+  pfgl.sig
+
+union all
+
+select 
+  '{{to}}'::timestamp as time,
+  concat('All_All_', pfgl.release) as series,
+  count(distinct pfgl.feature_gate) as value
+from 
+  pr_feature_gate_labels pfgl
+group by 
+  pfgl.release
+
+union all
+
+select 
+  '{{to}}'::timestamp as time,
+  concat('All_', pfgl.state, '_', pfgl.release) as series,
+  count(distinct pfgl.feature_gate) as value
+from 
+  pr_feature_gate_labels pfgl
+group by 
+  pfgl.state, pfgl.release
+
+union all
+
+select 
+  '{{to}}'::timestamp as time,
+  concat(pfgl.sig, '_All_', pfgl.release) as series,
+  count(distinct pfgl.feature_gate) as value
+from 
+  pr_feature_gate_labels pfgl
+group by 
+  pfgl.sig, pfgl.release
+
+union all
+
+select 
+  '{{to}}'::timestamp as time,
+  concat(pfgl.sig, '_', pfgl.state, '_All') as series,
+  count(distinct pfgl.feature_gate) as value
+from 
+  pr_feature_gate_labels pfgl
+group by 
+  pfgl.sig, pfgl.state

--- a/metrics/kubernetes/metrics.yaml
+++ b/metrics/kubernetes/metrics.yaml
@@ -559,6 +559,15 @@ metrics:
     periods: m
     merge_series: cntrs_and_orgs
     drop: 'scntrs_and_orgs'
+  - name: Feature Gates
+    series_name_or_func: multi_row_single_column
+    sql: feature_gates
+    periods: d,w,m,q,y
+    aggregate: 1,7
+    skip: w7,m7,q7,y7
+    multi_value: true
+    escape_value_name: true
+    annotations_ranges: true
   - name: Home dashboard (must be listed last)
     series_name_or_func: events_h
     sql: events


### PR DESCRIPTION
Implement feature gates tracking system to support data-driven decisions about eliminating beta stage for new features, as discussed in sig-architecture.

Components added:
- Feature gates SQL metric (metrics/kubernetes/feature_gates.sql)
  * Tracks feature gates across alpha/beta/GA/deprecated states
  * Associates features with SIGs and release milestones
  * Uses regex patterns to extract feature gate information from issues/PRs
  * Provides multi-dimensional aggregation for visualization

- Metrics configuration (metrics/kubernetes/metrics.yaml)
  * Multi-row single column series configuration
  * All time periods supported (d,w,m,q,y)
  * Annotations and aggregation enabled

- Grafana dashboard (grafana/dashboards/kubernetes/feature-gates-by-sig-and-state.json)
  * Feature gates by state over time visualization
  * Interactive filtering by period and states
  * Color-coded state progression (alpha=orange, beta=yellow, GA=green, deprecated=red)
  * Template variables for flexible analysis

- Comprehensive documentation (docs/FEATURE_GATES_ANALYSIS.md)
  * System overview and usage patterns
  * Decision support framework for sig-architecture
  * Implementation details and optimization recommendations

- Updated DASHBOARDS.md with feature gates dashboard entry

This system enables analysis of:
- Beta feature distribution and bottlenecks across SIGs
- Feature maturity progression patterns over time
- Release readiness assessment based on feature states
- Impact analysis for potential beta stage elimination

Supports: Kubernetes sig-architecture beta elimination discussion

Please make sure that you follow instructions from [CONTRIBUTING](https://github.com/cncf/devstats/blob/master/CONTRIBUTING.md)

Specially:
- Check if all tests pass, see [TESTING](https://github.com/cncf/devstats/blob/master/TESTING.md) for deatils.
- Make sure you've added test coverage for new features/metrics.
- Make sure you have updated documentation.
- If you added a new metric, please make sure you have been following instructions about [adding new metric](https://github.com/cncf/devstats/blob/master/METRICS.md).
