### PR TITLE
Fix company contribution calculation discrepancies in governance data

### DIFF
--- a/metrics/kubernetes/project_developer_stats.sql
+++ b/metrics/kubernetes/project_developer_stats.sql
@@ -1184,6 +1184,61 @@ where
   )
 )
 -- limit amount of data
+
+-- Add company-level aggregation using distinct event counting to match companies table logic
+-- This prevents discrepancies between individual developer sums and direct company calculations
+union select 'hdev_contributions_company,All_All' as metric,
+  coalesce(aa.company_name, 'Independent') as name,
+  count(distinct e.id) as value
+from
+  gha_events e
+left join
+  gha_actors_affiliations aa
+on
+  aa.actor_id = e.actor_id
+  and aa.dt_from <= e.created_at
+  and aa.dt_to > e.created_at
+where
+  e.type in (
+    'PushEvent', 'PullRequestEvent', 'IssuesEvent', 'PullRequestReviewEvent',
+    'CommitCommentEvent', 'IssueCommentEvent', 'PullRequestReviewCommentEvent'
+  )
+  and {{period:e.created_at}}
+  and (lower(e.dup_actor_login) {{exclude_bots}})
+  and coalesce(aa.company_name, '') != ''
+group by
+  aa.company_name
+having
+  count(distinct e.id) >= 30
+
+union select 'hdev_contributions_company,' || r.repo_group || '_All' as metric,
+  coalesce(aa.company_name, 'Independent') as name,
+  count(distinct e.id) as value
+from
+  gha_events e,
+  gha_repos r
+left join
+  gha_actors_affiliations aa
+on
+  aa.actor_id = e.actor_id
+  and aa.dt_from <= e.created_at
+  and aa.dt_to > e.created_at
+where
+  e.repo_id = r.id
+  and e.type in (
+    'PushEvent', 'PullRequestEvent', 'IssuesEvent', 'PullRequestReviewEvent',
+    'CommitCommentEvent', 'IssueCommentEvent', 'PullRequestReviewCommentEvent'
+  )
+  and {{period:e.created_at}}
+  and (lower(e.dup_actor_login) {{exclude_bots}})
+  and r.repo_group in (select repo_group_name from trepo_groups)
+  and coalesce(aa.company_name, '') != ''
+group by
+  r.repo_group,
+  aa.company_name
+having
+  count(distinct e.id) >= 30
+
 order by
   metric asc,
   value desc,


### PR DESCRIPTION
- Add company-level aggregation queries using count(distinct e.id) to both kubernetes and shared project_developer_stats.sql
- Prevents double-counting when multiple developers from same company work on same GitHub events
- Ensures consistency between companies table and developer activity dashboards for governance decisions
- Addresses Istio governance data discrepancy where Google showed 12738 vs 12615 contributions in different views
- Fixes potential ranking issues for top 5 company contributions across all CNCF projects

Please make sure that you follow instructions from [CONTRIBUTING](https://github.com/cncf/devstats/blob/master/CONTRIBUTING.md)

Specially:
- Check if all tests pass, see [TESTING](https://github.com/cncf/devstats/blob/master/TESTING.md) for deatils.
- Make sure you've added test coverage for new features/metrics.
- Make sure you have updated documentation.
- If you added a new metric, please make sure you have been following instructions about [adding new metric](https://github.com/cncf/devstats/blob/master/METRICS.md).
