### PR TITLE
 Docs(test): Fix typos and modernize test helper; minor comment cleanups

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,7 +33,7 @@ Project uses use GitHub archives and local copy of all git repositories. The pos
 - All projects repositories are cloned into local directory
 - All projects repositories are updated every hour using `git` (part of standard cron workflow).
 - For all commits retrieved from GitHub archives we are storing list of modified (modified, added, deleted) files and their size (at the commit time).
-- This allows file name analsysis, assigning given files from repositories to repository groups (file level granularity) and file size analysis (for example file size growth in time).
+- This allows file name analysis, assigning given files from repositories to repository groups (file level granularity) and file size analysis (for example, file size growth in time).
 - cncf/gitdm uses git to GitHub connection from git pushes to allow connecting committers with their GitHub accounts. This is used to determine committers company affiliations.
 
 # Architecture
@@ -87,10 +87,10 @@ We're getting all possible GitHub data for all objects, and all objects historic
 - It creates PID file `/tmp/devstats.pid` while it is running, so it is safe when instances overlap.
 - It is called by cron job on 1:10, 2:10, ... and so on - GitHub archive publishes new file every hour, so we're off by at most 1 hour.
 
-6) `get_repos`: it can update list of all projects repositories (clone and/or pull as needed), update each commits files list, display all repos and orgs data bneeded by `cncf/gitdm`.
+- `get_repos`: it can update list of all projects repositories (clone and/or pull as needed), update each commits files list, display all repos and orgs data needed by `cncf/gitdm`.
 - [get_repos](https://github.com/cncf/devstats/blob/master/cmd/get_repos/get_repos.go)
 - `get_repos` is used to clone or pull all repos used in all `devstats` project in a location from `GHA2DB_REPOS_DIR` environment variable, or by default in "~/devstats_repos/".
-- Those repos are used later to search for commit SHA's using `git log` to determine files modifed by particular commits and other objects.
+- Those repos are used later to search for commit SHA's using `git log` to determine files modified by particular commits and other objects.
 - It can also be used to return list of all distinct repos and their locations - this can be used by `cncf/gitdm` to create concatenated `git.log` from all repositories for affiliations analysis.
 - This tool is also used to create/update mapping between commits and list of files that given commit refers to, it also keep file sizes info at the commit time.
 
@@ -115,9 +115,9 @@ We're getting all possible GitHub data for all objects, and all objects historic
 - `tags` is used to add tags. Those tags are used to populate Grafana template drop-down values and names. This is used to auto-populate Repository groups drop down, so when somebody adds new repository group - it will automatically appear in the drop-down.
 - `tags` uses [tags.yaml](https://github.com/cncf/devstats/blob/master/metrics/kubernetes/tags.yaml) file to configure tags generation.
 - [columns](https://github.com/cncf/devstats/blob/master/cmd/columns/columns.go)
-- `columns` is used to specify which columns are mandatory on which time series tables (because missing column is an error in Postgres). You can define table9s) by regexp and then specify which columns are mandatory by specifying tags table and column.
+- `columns` is used to specify which columns are mandatory on which time series tables (because missing column is an error in Postgres). You can define tables by regexp and then specify which columns are mandatory by specifying tags table and column.
 - `columns` uses [columns.yaml](https://github.com/cncf/devstats/blob/master/metrics/kubernetes/columns.yaml) file to configure mandatory columns.
-- You can use all defined environments variables, but add `_SRC` suffic for source database and `_DST` suffix for destination database.
+- You can use all defined environments variables, but add `_SRC` suffix for source database and `_DST` suffix for destination database.
 - [webhook](https://github.com/cncf/devstats/blob/master/cmd/webhook/webhook.go)
 - `webhook` is used to react to Travis CI webhooks and trigger deploy if status, branch and type match defined values, more details [here](https://github.com/cncf/devstats/blob/master/CONTINUOUS_DEPLOYMENT.md).
 - Add `[no deploy]` to the commit message, to skip deploying.
@@ -126,7 +126,7 @@ We're getting all possible GitHub data for all objects, and all objects historic
 - There are few shell scripts for example: running sync every N seconds, setup time series data etc.
 - [merge_dbs](https://github.com/cncf/devstats/blob/master/cmd/merge_dbs/merge_dbs.go)
 - `merge_dbs` is used to generate Postgres database that contains data from other multiple databases.
-- You can use `merge_dbs` to add new projects to a existing database, but please consider running './devel/remove_db_dups.sh' then or use: './all/add_project.sh' script.
+- You can use `merge_dbs` to add new projects to an existing database, but please consider running './devel/remove_db_dups.sh' then or use: './all/add_project.sh' script.
 - [replacer](https://github.com/cncf/devstats/blob/master/cmd/replacer/replacer.go)
 - `replacer` is used to mass replace data in text files. It has regexp modes, string modes, terminate on no match etc.
 - Supports MODE, FROM, TO, NREPLACES, REPLACEFROM environment variables, see `devel/replace.sh` script for examples.

--- a/USAGE.md
+++ b/USAGE.md
@@ -43,13 +43,13 @@ Uses GNU `Makefile`:
 All `*.go` files in project root directory are common library `gha2db` for all go executables.
 All `*_test.go` and `test/*.go` are Go test files, that are used only for testing.
 
-To run tools locally (without install) prefix them with `GHA2DB_LOCAl=1 `.
+To run tools locally (without install) prefix them with `GHA2DB_LOCAL=1 `.
 
 # Usage:
 
 Local:
 - `make`
-- `ENV_VARIABLES GHA2DB_LOCAl=1 gha2db YYYY-MM-DD HH YYYY-MM-DD HH [org [repo]]`.
+- `ENV_VARIABLES GHA2DB_LOCAL=1 gha2db YYYY-MM-DD HH YYYY-MM-DD HH [org [repo]]`.
 
 Installed:
 - `make`
@@ -101,7 +101,7 @@ You can tweak `devstats` tools by environment variables:
 - Set `GHA2DB_SKIPLOG` for any tool to skip logging output to `gha_logs` table in `devstats` database.
 - Set `GHA2DB_LOCAL` for `gha2db_sync` tool to make it prefix call to other tools with "./" (so it will use other tools binaries from the current working directory instead of `/usr/bin/`). Local mode uses "./metrics/{{project}}/" to search for metrics files. Otherwise "/etc/gha2db/metrics/{{project}}/" is used.
 - Set `GHA2DB_METRICS_YAML` for `gha2db_sync` tool, set name of metrics yaml file, default is "metrics/{{project}}/metrics.yaml".
-- Set `GHA2DB_GAPS_YAML` for `gha2db_sync` tool, set name of gaps yaml file, default is "metrics/{{project}}/gaps.yaml". Please use Grafana's "null as zero" instead of using manuall filling gaps. This simplifies metrics a lot.
+- Set `GHA2DB_GAPS_YAML` for `gha2db_sync` tool, set name of gaps yaml file, default is "metrics/{{project}}/gaps.yaml". Please use Grafana's "null as zero" instead of using manual filling of gaps. This simplifies metrics a lot.
 - Set `GHA2DB_GITHUB_OAUTH` for `annotations` tool, if not set reads from `/etc/github/oauths` (multiple comma separated tokens) or `/etc/github/oauth` (single token) file. Set to "-" to force public access. **annotations tool is not using GitHub API anymore, it uses `git_tags.sh` script instead.**
 - Set `GHA2DB_MAXLOGAGE` for `gha2db_sync` tool, maximum age of DB logs stored in `devstats`.`gha_logs` table, default "1 week" (logs are cleared in `gha2db_sync` job).
 - Set `GHA2DB_TRIALS` for tools that use Postgres DB, set retry periods when "too many connection open" psql error appears, default is "10,30,60,120,300,600" (so 30s, 1min, 2min, 5min, 10min).
@@ -156,13 +156,13 @@ Examples in this shell script (some commented out, some not):
 
 You can use [this](https://pgtune.leopard.in.ua/#/) website to generate tuned values for `postgresql.conf` file.
 
-# Informations
+# Information
 
 GitHub archives keep data as Gzipped JSONs for each hour (24 gzipped JSONs per day).
 Single JSON is not a real JSON file, but "\n" newline separated list of JSONs for each GitHub event in that hour.
 So this is a JSON array in reality.
 
-GihHub archive files can be found [here](http://www.gharchive.org).
+GitHub archive files can be found [here](http://www.gharchive.org).
 
 For example to fetch 2017-08-03 18:00 UTC can be fetched by:
 
@@ -223,7 +223,7 @@ Defaults are:
 - If you want to skip table creations set `GHA2DB_SKIPTABLE` environment variable (when `GHA2DB_INDEX` also set, it will create indexes on already existing table structure, possibly already populated)
 - If you want to skip creating DB tools (like views and functions), use `GHA2DB_SKIPTOOLS` environment variable.
 
-It is recommended to create structure without indexes first (the default), then get data from GHA and populate array, and finally add indexes. To do do:
+It is recommended to create structure without indexes first (the default), then get data from GHA and populate array, and finally add indexes. To do so:
 - `time PG_PASS=your_password structure`
 - `time PG_PASS=your_password ./scripts/gha2db.sh`
 - `time GHA2DB_SKIPTABLE=1 GHA2DB_INDEX=1 PG_PASS=your_password structure` (will take some time to generate indexes on populated database)
@@ -339,7 +339,7 @@ For example June 2017:
 To process kubernetes all time just use `kubernetes/psql.sh` script. Like this:
 - `time PG_PASS=pwd ./kubernetes/psql.sh`.
 
-# Check erros
+# Check errors
 
 To see if there are any errors please use script: `PG_PASS=... ./devel/get_errors.sh`.
 
@@ -389,7 +389,7 @@ Example call:
 
 Sync tool uses [gaps.yaml](https://github.com/cncf/devstats/blob/master/metrics/kubernetes/gaps.yaml), to prefill some series with zeros.
 This is needed for metrics (like SIG mentions or PRs merged) that return multiple rows, depending on data range.
-Please use Grafana's "null as zero" instead of using manuall filling gaps. This simplifies metrics a lot.
+Please use Grafana's "null as zero" instead of using manual filling of gaps. This simplifies metrics a lot.
 Sync tool read project definition from [projects.yaml](https://github.com/cncf/devstats/blob/master/projects.yaml)
 
 You can also use `devstats` tool that calls `gha2db_sync` for all defined projects and also updates local copy of all git repos using `get_repos`.

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -3,7 +3,6 @@ package devstats
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"reflect"
@@ -346,7 +345,7 @@ func dataForMetricTestCase(con *sql.DB, ctx *lib.Ctx, testMetric *metricTestCase
 // All metric data is defined in "testMetric" argument
 // Single metric test is dropping & creating database from scratch (to avoid junky database)
 // It also creates full DB structure - without indexes - they're not needed in
-// small databases - like the ones created by test covergae tools
+// small databases - like the ones created by test coverage tools
 func executeMetricTestCase(testMetric *metricTestCase, tests *metricTests, ctx *lib.Ctx) (result [][]interface{}, err error) {
 	// Drop database if exists
 	lib.DropDatabaseIfExists(ctx)
@@ -803,7 +802,7 @@ func addComment(con *sql.DB, ctx *lib.Ctx, args ...interface{}) (err error) {
 		nil,        // position
 		nil,        // original_position
 		nil,        // path
-		nil,        // pull_request_review_ai
+	nil,        // pull_request_review_id
 		nil,        // line
 		args[7],    // actor_id
 		args[8],    // actor_login
@@ -837,7 +836,7 @@ func addPayload(con *sql.DB, ctx *lib.Ctx, args ...interface{}) (err error) {
 	}
 	newArgs := lib.AnyArray{
 		args[0], // event_id
-		nil,     // push_id, size, ref, head, befor
+	nil,     // push_id, size, ref, head, before
 		nil,
 		nil,
 		nil,
@@ -904,7 +903,7 @@ func addPR(con *sql.DB, ctx *lib.Ctx, args ...interface{}) (err error) {
 		args[11], // PR.MergedAt
 		"9c31bcbc683a491c3d4122adcfe4caaab6e2d0fc", // PR.MergeCommitSHA
 		args[12],   // PR.Merged
-		true,       // PR.mergable
+	true,       // PR.mergeable
 		true,       // PR.Rebaseable
 		"clean",    // PR.MergeableState (nil, unknown, clean, unstable, dirty)
 		1,          // PR.Comments
@@ -1052,7 +1051,7 @@ func addMilestone(con *sql.DB, ctx *lib.Ctx, args ...interface{}) (err error) {
 func interfaceToYaml(fn string, i *[][]interface{}) (err error) {
 	yml, err := yaml.Marshal(i)
 	lib.FatalOnError(err)
-	lib.FatalOnError(ioutil.WriteFile(fn, yml, 0644))
+	lib.FatalOnError(os.WriteFile(fn, yml, 0644))
 	return
 }
 


### PR DESCRIPTION
## Summary
- Docs: fix multiple typos and grammar in `USAGE.md` and `ARCHITECTURE.md` (developer-facing accuracy/readability).
- Tests: replace deprecated `ioutil.WriteFile` with `os.WriteFile` in `metrics_test.go` (Go 1.16+ API; repo uses Go 1.20).
- Comments: correct in-file comments (`pull_request_review_id`, `mergeable`, etc.) and small wording fixes in test code.

No functional behavior changes; production binaries untouched. Changes are limited to documentation and a test helper.

## Reasoning and impact
- Reduces friction for contributors reading setup/usage docs.
- Removes a deprecated API from tests, aligning with the module's Go 1.20 toolchain.
- Comment fixes prevent confusion during maintenance.

## Files changed
- `USAGE.md`: fix `GHA2DB_LOCAL` spelling, section titles, and wording; fix “GitHub archive files”, “Check errors”, and phrasing around gap filling.
- `ARCHITECTURE.md`: fix spelling/grammar (“analysis”, “needed”, “tables”, etc.), and wording around repo/columns notes.
- `metrics_test.go`: switch to `os.WriteFile`, fix comment typos, and correct a few docstrings.

## How I validated
- Scanned the tree for deprecated `ioutil.*` usage (none remaining).
- Verified that only documentation and test code were touched; main packages are unchanged.
- The change is Go 1.16+ compatible (module requires Go 1.20), so compile behavior is unaffected.

## Backwards compatibility
- No schema, flags, or public APIs changed.
- Docs and comment updates are non-breaking.
- 
## Checklist
- [x] DCO sign-off included.
- [x] Focused, low-risk changes; no new features.
- [x] Does not break existing functionality.