### PR TITLE
Fix: safe shell argument forwarding and quoting in scripts

### DIFF
--- a/devel/execute_on_all_databases.sh
+++ b/devel/execute_on_all_databases.sh
@@ -7,7 +7,7 @@ fi
 . ./devel/all_dbs.sh || exit 2
 for db in $all
 do
-  for sql in $*
+  for sql in "$@"
   do
     echo "Execute script '$sql' on '$db' database"
     ./devel/db.sh psql "$db" < "$sql" || exit 2

--- a/devel/execute_on_all_databases_k8s.sh
+++ b/devel/execute_on_all_databases_k8s.sh
@@ -34,7 +34,7 @@ fi
 . ./devel/all_dbs.sh || exit 2
 for db in $all
 do
-  for sql in $*
+  for sql in "$@"
   do
     echo "Execute script '$sql' on '$db' database"
     kubectl exec -in "devstats-${kenv2}" "${member}" -- psql "$db" < "$sql"

--- a/devel/mass_update.sh
+++ b/devel/mass_update.sh
@@ -10,7 +10,7 @@ then
   echo "You need to set TO, example FROM=abc TO=xyz $0 ./some_dir/*"
   exit 2
 fi
-for f in $*
+for f in "$@"
 do
   ls -l "$f"
   # vim --not-a-term -c "%s/${FROM}/${TO}/g" -c "wq!" "$f"

--- a/git-lfs-diff.sh
+++ b/git-lfs-diff.sh
@@ -19,10 +19,10 @@ object() {
         return
     fi
 
-    Oid=$(git show $Rev:$File 2> /dev/null | grep "sha256" | cut -d ":" -f 2)
+    Oid=$(git show "${Rev}:${File}" 2> /dev/null | grep "sha256" | cut -d ":" -f 2)
     if [ "$Oid" != "" ]; then
-        Oid12=$(echo $Oid | cut -b 1-2)
-        Oid34=$(echo $Oid | cut -b 3-4)
+        Oid12=$(echo "$Oid" | cut -b 1-2)
+        Oid34=$(echo "$Oid" | cut -b 3-4)
         Object=.git/lfs/objects/$Oid12/$Oid34/$Oid
         if [ ! -e "$Object" ]; then
             echo "Missing file $File at revision $Rev"
@@ -34,14 +34,14 @@ object() {
 }
 
 
-ObjectA=$(object $RevA $File)
+ObjectA=$(object "$RevA" "$File")
 EC="$?"
 if [ "$EC" != "0" ]; then
     echo "$ObjectA"
     exit "$EC"
 fi
 
-ObjectB=$(object $RevB $File)
+ObjectB=$(object "$RevB" "$File")
 EC="$?"
 if [ "$EC" != "0" ]; then
     echo "$ObjectB"

--- a/util_sh/monitor_command.sh
+++ b/util_sh/monitor_command.sh
@@ -34,7 +34,7 @@ then
 fi
 
 # Run command, store pid as $pid
-( $* ) & pid=$!
+( "$@" ) & pid=$!
 # Spawn watcher that waits TIMEOUT seconds and then kills command gracefully via kill -HUP, store watcher pid as $wather
 ( sleep $TIMEOUT && kill -HUP $pid ) 2>/dev/null & watcher=$!
 


### PR DESCRIPTION
# Summary
This PR makes focused, low-risk improvements to shell scripts without changing any existing features:
- Use "$@" instead of $* where scripts iterate over or execute user-supplied arguments, preserving spaces and special characters.
- Add safer quoting in git-lfs-diff.sh when reading Git LFS pointers and computing object paths.

Updated files:
- devel/execute_on_all_databases.sh
- devel/execute_on_all_databases_k8s.sh
- devel/mass_update.sh
- util_sh/monitor_command.sh
- git-lfs-diff.sh

# Reasoning
-  collapses all parameters into a single word separated by the first character of IFS, which breaks when arguments include spaces or glob characters. "$@" preserves each original argument.
- Quoting variable expansions and the revision:path argument in git-lfs-diff.sh prevents word-splitting and path parsing issues for file names with spaces.

# Impact
- Improves correctness and stability when scripts are invoked with multiple arguments and file names containing spaces.
- No behavioral changes beyond safer argument handling. Default flows and outputs are preserved.

# Verification
- Changes are POSIX-compatible for /bin/sh scripts and compatible with /bin/bash for bash scripts.
- The diff is limited to argument iteration/execution lines and quoting; no logic was altered.