### PR TITLE
Fix inconsistent contribution thresholds affecting election eligibility

### DIFF
--- a/metrics/kubernetes/project_developer_stats.sql
+++ b/metrics/kubernetes/project_developer_stats.sql
@@ -276,9 +276,9 @@ from (
   ) sub
 -- limit amount of data
 where
-  (sub.metric = 'events' and sub.value >= 200)
+  (sub.metric = 'events' and sub.value >= 100)
   or (sub.metric = 'active_repos' and sub.value >= 3)
-  or (sub.metric = 'contributions' and sub.value >= 30)
+  or (sub.metric = 'contributions' and sub.value >= 5)
   or (sub.metric = 'commit_comments' and sub.value >= 10)
   or (sub.metric = 'comments' and sub.value >= 20)
   or (sub.metric = 'raw_reviews' and sub.value >= 15)
@@ -811,7 +811,7 @@ from (
 where
   (sub.metric = 'events' and sub.value >= 100)
   or (sub.metric = 'active_repos' and sub.value >= 3)
-  or (sub.metric = 'contributions' and sub.value >= 15)
+  or (sub.metric = 'contributions' and sub.value >= 5)
   or (sub.metric = 'commit_comments' and sub.value >= 5)
   or (sub.metric = 'comments' and sub.value >= 15)
   or (sub.metric = 'raw_reviews' and sub.value >= 10)

--- a/metrics/shared/project_developer_stats.sql
+++ b/metrics/shared/project_developer_stats.sql
@@ -264,21 +264,21 @@ from (
   ) sub
 -- limit amount of data
 where
-  (sub.metric = 'events' and sub.value > 100 * {{project_scale}} * sqrt({{range}}/1450.0))
+  (sub.metric = 'events' and sub.value > 80 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric = 'active_repos' and sub.value > 3 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'contributions' and sub.value > 10 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'commit_comments' and sub.value > 3 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'comments' and sub.value > 20 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'reviews' and sub.value > 15 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'issue_comments' and sub.value > 20 * {{project_scale}} * sqrt({{range}}/1450.0))
-  or (sub.metric = 'review_comments' and sub.value > 20 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'contributions' and sub.value > 5 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'commit_comments' and sub.value > 2 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'comments' and sub.value > 10 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'reviews' and sub.value > 5 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'issue_comments' and sub.value > 10 * {{project_scale}} * sqrt({{range}}/1450.0))
+  or (sub.metric = 'review_comments' and sub.value > 10 * {{project_scale}} * sqrt({{range}}/1450.0))
   or (sub.metric in (
     'commits',
     'pushes',
     'issues',
     'prs',
     'merged_prs'
-  ) and sub.value > 0.8 * {{project_scale}} * sqrt({{range}}/1450.0)
+  ) and sub.value > 0.5 * {{project_scale}} * sqrt({{range}}/1450.0)
 )
 -- limit amount of data
 union select 'hdev_' || sub.metric || ',' || sub.repo_group || '_All' as metric,


### PR DESCRIPTION
- Standardize contribution thresholds across all developer statistics queries
- Shared project stats: Reduce 'All' repository group thresholds from 10/15/20 to 5/5/10 contributions to match specific repository groups
- Kubernetes project stats: Reduce 'All' repository group thresholds from 200/30 to 100/5 contributions for consistency
- Ensures OpenTelemetry and other CNCF projects have consistent voter eligibility across different dashboard views
- Fixes issue where 'All' repository group showed different developer counts than specific repository groups
- Critical for election integrity: prevents eligible developers from being excluded due to inconsistent filtering
- Aligns all query types to use lower, more inclusive thresholds while maintaining data quality

Please make sure that you follow instructions from [CONTRIBUTING](https://github.com/cncf/devstats/blob/master/CONTRIBUTING.md)

Specially:
- Check if all tests pass, see [TESTING](https://github.com/cncf/devstats/blob/master/TESTING.md) for deatils.
- Make sure you've added test coverage for new features/metrics.
- Make sure you have updated documentation.
- If you added a new metric, please make sure you have been following instructions about [adding new metric](https://github.com/cncf/devstats/blob/master/METRICS.md).
