### PR TITLE
add istio-ecosystem org to Istio

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2043,7 +2043,7 @@ projects:
     name: Istio
     status: Graduated
     command_line:
-      - istio
+      - istio,istio-ecosystem
     start_date: 2016-12-01T00:00:00Z
     join_date: 2022-09-30T00:00:00Z
     graduated_date: 2023-07-12T00:00:00Z


### PR DESCRIPTION
The Istio Steering Committee has taken the decision to include counts for the istio-ecosystem org in the project contributions.

Unfortunately I wasn't able to setup a local test environment, some of the documentation seems to be outdated, but I hope this small change does not require extensive testing.

Please make sure that you follow instructions from [CONTRIBUTING](https://github.com/cncf/devstats/blob/master/CONTRIBUTING.md)

Specially:
- Check if all tests pass, see [TESTING](https://github.com/cncf/devstats/blob/master/TESTING.md) for deatils.
- Make sure you've added test coverage for new features/metrics.
- Make sure you have updated documentation.
- If you added a new metric, please make sure you have been following instructions about [adding new metric](https://github.com/cncf/devstats/blob/master/METRICS.md).
