### PR TITLE
Add headlamp to SIG UI repo group

### DIFF
--- a/scripts/kubernetes/repo_groups.sql
+++ b/scripts/kubernetes/repo_groups.sql
@@ -405,6 +405,7 @@ update gha_repos set repo_group = 'SIG UI' where lower(name) in (
   'kubernetes-graveyard/kube-ui',
   'kubernetes-retired/kube-ui',
   'kubernetes-sigs/dashboard-metrics-scraper',
+  'kubernetes-sigs/headlamp',
   'kubernetes/console',
   'kubernetes/dashboard',
   'kubernetes/kube-ui',


### PR DESCRIPTION
This PR adds the `kubernetes-sigs/headlamp` repository to the SIG UI group. Headlamp is an official subproject of SIG UI and needs this mapping for accurate DevStats tracking.

cc: @joaquimrocha @illume @sniok @yolossn @ashu8912